### PR TITLE
drivers: fpc1020_ree: add sysfs for disabling key emulation

### DIFF
--- a/drivers/fingerprint/fpc1020_ree.c
+++ b/drivers/fingerprint/fpc1020_ree.c
@@ -79,6 +79,8 @@ extern void reset_home_button(void);
 
 bool reset;
 
+static bool utouch_disable;
+
 static int fb_notifier_callback(struct notifier_block *self,
 		unsigned long event, void *data);
 
@@ -130,7 +132,7 @@ static ssize_t set_key(struct device *device,
 	bool home_pressed;
 
 	retval = kstrtou64(buffer, 0, &val);
-	if (!retval) {
+	if (!retval && !utouch_disable) {
 		if (val == KEY_HOME)
 			/* Convert to U-touch long press keyValue */
 			val = KEY_NAVI_LONG;
@@ -148,12 +150,40 @@ static ssize_t set_key(struct device *device,
 			pr_info("calling home key reset");
 			reset_home_button();
 		}
-	} else
+	} else if (retval)
 		return -ENOENT;
 	return strnlen(buffer, count);
 }
 
 static DEVICE_ATTR(key, S_IRUSR | S_IWUSR, get_key, set_key);
+
+static ssize_t utouch_store_disable(struct device *dev, 
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+    int value;
+ 	if (1 != sscanf(buf, "%d", &value)) {
+		dev_err(dev, "Failed to parse integer: <%s>\n", buf);
+		return -EINVAL;
+	}
+ 	if (value == 1) {
+		utouch_disable = true;
+		pr_info("utouch disabled\n");
+	} else {
+		utouch_disable = false;
+		pr_info("utouch enabled\n");
+	}
+ 	return count;
+}
+
+static ssize_t utouch_show_disable(struct device *dev, 
+		struct device_attribute *attr, char *buf)
+{
+	if (utouch_disable)
+		return sprintf(buf, "1\n"); 
+	else
+		return sprintf(buf, "0\n"); 
+}
+static DEVICE_ATTR(utouch_disable, S_IRUGO|S_IWUSR, utouch_show_disable, utouch_store_disable);
 
 static ssize_t enable_wakeup_show(struct device *dev,
 			struct device_attribute *attr, char *buf)
@@ -212,6 +242,7 @@ static struct attribute *attributes[] = {
 	&dev_attr_key.attr,
 	&dev_attr_enable_wakeup.attr,
 	&dev_attr_proximity_state.attr,
+	&dev_attr_utouch_disable.attr,
 	NULL
 };
 


### PR DESCRIPTION
- needed for KeyDisabler

Signed-off-by: Davide Garberi <dade.garberi@gmail.com>